### PR TITLE
Part1Greedy 기지국 설치 문제

### DIFF
--- a/binna/0_Don'tFailTheTestKit_Java/part1_greedy/myCode.txt
+++ b/binna/0_Don'tFailTheTestKit_Java/part1_greedy/myCode.txt
@@ -1,0 +1,31 @@
+import java.util.*;
+class Solution {
+    public int solution(int n, int[] stations, int w) {
+        int answer = 0;
+        List<Integer> list = new ArrayList<>();
+
+        int standard = 1;
+        double scope = w * 2 + 1;
+        for (int station : stations) {
+            int frontNum = station - w;
+            int backNum = station + w;
+            
+            int num = frontNum - standard;
+            answer += Math.ceil((double) num / scope);
+            
+            standard = backNum + 1;
+        }
+        
+        if (standard <= n) {
+            int num = n - standard + 1;
+            answer += Math.ceil((double) num / scope);
+        }
+        
+        // for (int num : list) {
+        //     double scope = w * 2 + 1;
+        //     answer += Math.ceil((double) num / scope);
+        // }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
[프로그래머스 문제로 가기](https://school.programmers.co.kr/learn/courses/30/lessons/12979)

N개의 아파트가 일렬로 쭉 늘어서 있습니다. 이 중에서 일부 아파트 옥상에는 4g 기지국이 설치되어 있습니다. 기술이 발전해 5g 수요가 높아져 4g 기지국을 5g 기지국으로 바꾸려 합니다. 그런데 5g 기지국은 4g 기지국보다 전달 범위가 좁아, 4g 기지국을 5g 기지국으로 바꾸면 어떤 아파트에는 전파가 도달하지 않습니다.

예를 들어 11개의 아파트가 쭉 늘어서 있고, [4, 11] 번째 아파트 옥상에는 4g 기지국이 설치되어 있습니다. 만약 이 4g 기지국이 전파 도달 거리가 1인 5g 기지국으로 바뀔 경우 모든 아파트에 전파를 전달할 수 없습니다. (전파의 도달 거리가 W일 땐, 기지국이 설치된 아파트를 기준으로 전파를 양쪽으로 W만큼 전달할 수 있습니다.)

초기에, 1, 2, 6, 7, 8, 9번째 아파트에는 전파가 전달되지 않습니다.

1, 7, 9번째 아파트 옥상에 기지국을 설치할 경우, 모든 아파트에 전파를 전달할 수 있습니다.

더 많은 아파트 옥상에 기지국을 설치하면 모든 아파트에 전파를 전달할 수 있습니다.

이때, 우리는 5g 기지국을 최소로 설치하면서 모든 아파트에 전파를 전달하려고 합니다. 위의 예시에선 최소 3개의 아파트 옥상에 기지국을 설치해야 모든 아파트에 전파를 전달할 수 있습니다.

아파트의 개수 N, 현재 기지국이 설치된 아파트의 번호가 담긴 1차원 배열 stations, 전파의 도달 거리 W가 매개변수로 주어질 때, 모든 아파트에 전파를 전달하기 위해 증설해야 할 기지국 개수의 최솟값을 리턴하는 solution 함수를 완성해주세요